### PR TITLE
add reviewmeta to skip blacklist

### DIFF
--- a/Skip_Redirect-Blacklist.txt
+++ b/Skip_Redirect-Blacklist.txt
@@ -78,6 +78,7 @@ on.crisp.email/
 paypal.com/
 phish-report.mozilla.com/
 reddit.com/
+reviewmeta.com/
 rover.ebay.co
 safelinks.protection.outlook.com/
 securityheaders.com/


### PR DESCRIPTION
Here's a PR that simply adds reviewmeta.com to the skip redirect blacklist. Reviewmeta is a review analysis website that generates reports on amazon (and other website) urls. Skip Redirect's default skip all mode breaks the functionality.
PS. thanks for the firefox config. It's made life on the privacy invading web much more comfortable.